### PR TITLE
Add blog follow feature

### DIFF
--- a/app/api/follow/route.ts
+++ b/app/api/follow/route.ts
@@ -1,0 +1,43 @@
+import { NextRequest, NextResponse } from "next/server"
+import { followBlog, unfollowBlog, getFollowerCount, isFollowing } from "@/lib/firebase-services"
+
+export async function POST(request: NextRequest) {
+  try {
+    const { userId } = await request.json()
+    if (!userId) {
+      return NextResponse.json({ success: false, message: "Missing userId" }, { status: 400 })
+    }
+    await followBlog(userId)
+    return NextResponse.json({ success: true })
+  } catch (error: any) {
+    console.error("Error adding follower:", error)
+    return NextResponse.json({ success: false, error: error.message }, { status: 500 })
+  }
+}
+
+export async function DELETE(request: NextRequest) {
+  try {
+    const { userId } = await request.json()
+    if (!userId) {
+      return NextResponse.json({ success: false, message: "Missing userId" }, { status: 400 })
+    }
+    await unfollowBlog(userId)
+    return NextResponse.json({ success: true })
+  } catch (error: any) {
+    console.error("Error removing follower:", error)
+    return NextResponse.json({ success: false, error: error.message }, { status: 500 })
+  }
+}
+
+export async function GET(request: NextRequest) {
+  try {
+    const { searchParams } = new URL(request.url)
+    const userId = searchParams.get("userId")
+    const count = await getFollowerCount()
+    const following = userId ? await isFollowing(userId) : false
+    return NextResponse.json({ success: true, count, isFollowing: following })
+  } catch (error: any) {
+    console.error("Error getting followers:", error)
+    return NextResponse.json({ success: false, error: error.message }, { status: 500 })
+  }
+}

--- a/app/blogs/[slug]/page.tsx
+++ b/app/blogs/[slug]/page.tsx
@@ -6,6 +6,7 @@ import Link from "next/link"
 import { Card, CardContent } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
 import { Calendar, Clock, User, ArrowLeft } from "lucide-react"
+import { FollowButton } from "@/components/follow-button"
 import { Header } from "@/components/header"
 import { notFound } from "next/navigation"
 import { useBlogPost, useBlogPosts } from "@/hooks/useFirebaseData"
@@ -44,6 +45,9 @@ export default function BlogPostPage({ params }: BlogPostPageProps) {
             <ArrowLeft className="w-4 h-4" />
             <span>Back to Blogs</span>
           </Link>
+          <div className="mb-8 text-right">
+            <FollowButton />
+          </div>
 
           {/* Article Header */}
           <div className="mb-12">

--- a/app/blogs/page.tsx
+++ b/app/blogs/page.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useState } from "react"
+import { useState, useEffect } from "react"
 import Link from "next/link"
 import Image from "next/image"
 import { Card, CardContent } from "@/components/ui/card"
@@ -11,6 +11,7 @@ import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { Header } from "@/components/header"
 import { LoadingSection } from "@/components/loading-spinner"
 import { Calendar, Clock, Search, ArrowRight, TrendingUp, ThumbsUp, MessageSquare, Eye } from "lucide-react"
+import { FollowButton } from "@/components/follow-button"
 import { useBlogPosts, useFeaturedPosts } from "@/hooks/useFirebaseData"
 
 export default function BlogsPage() {
@@ -18,6 +19,20 @@ export default function BlogsPage() {
   const { posts: featuredPosts, loading: featuredLoading } = useFeaturedPosts()
   const [searchQuery, setSearchQuery] = useState("")
   const [activeTab, setActiveTab] = useState("all")
+  const [followerCount, setFollowerCount] = useState(0)
+
+  useEffect(() => {
+    const loadFollowers = async () => {
+      try {
+        const res = await fetch("/api/follow")
+        const data = await res.json()
+        if (data.count !== undefined) setFollowerCount(data.count)
+      } catch {
+        // ignore
+      }
+    }
+    loadFollowers()
+  }, [])
 
   // Extract categories from posts
   const categories = Array.from(new Set(allPosts.map((post) => post.category).filter(Boolean)))
@@ -28,6 +43,7 @@ export default function BlogsPage() {
     totalViews: allPosts.reduce((sum, post) => sum + Number.parseInt(post.views?.replace(/[^\d]/g, "") || "0"), 0),
     totalLikes: allPosts.reduce((sum, post) => sum + Number.parseInt(post.likes || "0"), 0),
     totalComments: allPosts.reduce((sum, post) => sum + Number.parseInt(post.comments || "0"), 0),
+    followers: followerCount,
   }
 
   // Filter posts based on search query and active tab
@@ -78,6 +94,9 @@ export default function BlogsPage() {
               />
               <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 text-muted-foreground" />
             </div>
+            <div className="mt-6">
+              <FollowButton />
+            </div>
           </div>
         </div>
       </section>
@@ -85,7 +104,7 @@ export default function BlogsPage() {
       {/* Stats Section */}
       <section className="py-10 bg-muted/30">
         <div className="container mx-auto px-4">
-          <div className="grid grid-cols-2 md:grid-cols-4 gap-8">
+          <div className="grid grid-cols-2 md:grid-cols-5 gap-8">
             <div className="text-center">
               <div className="text-3xl lg:text-4xl font-bold text-teal-400 mb-2">{blogStats.totalPosts}</div>
               <div className="text-muted-foreground">Articles</div>
@@ -103,6 +122,10 @@ export default function BlogsPage() {
             <div className="text-center">
               <div className="text-3xl lg:text-4xl font-bold text-teal-400 mb-2">{blogStats.totalComments}</div>
               <div className="text-muted-foreground">Comments</div>
+            </div>
+            <div className="text-center">
+              <div className="text-3xl lg:text-4xl font-bold text-teal-400 mb-2">{blogStats.followers}</div>
+              <div className="text-muted-foreground">Followers</div>
             </div>
           </div>
         </div>

--- a/components/follow-button.tsx
+++ b/components/follow-button.tsx
@@ -1,0 +1,74 @@
+"use client"
+
+import { useState, useEffect } from "react"
+import Link from "next/link"
+import { Button } from "@/components/ui/button"
+import { useAuth } from "@/contexts/auth-context"
+
+export function FollowButton() {
+  const { user } = useAuth()
+  const [following, setFollowing] = useState(false)
+  const [loading, setLoading] = useState(false)
+
+  useEffect(() => {
+    const check = async () => {
+      if (!user) return
+      try {
+        const res = await fetch(`/api/follow?userId=${user.uid}`)
+        const data = await res.json()
+        if (data.isFollowing) setFollowing(true)
+      } catch {
+        // ignore
+      }
+    }
+    check()
+  }, [user])
+
+  const follow = async () => {
+    if (!user) return
+    setLoading(true)
+    try {
+      await fetch("/api/follow", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ userId: user.uid }),
+      })
+      setFollowing(true)
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  const unfollow = async () => {
+    if (!user) return
+    setLoading(true)
+    try {
+      await fetch("/api/follow", {
+        method: "DELETE",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ userId: user.uid }),
+      })
+      setFollowing(false)
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  if (!user) {
+    return (
+      <Link href="/auth/login">
+        <Button className="bg-teal-400 text-gray-900 hover:bg-teal-500">Follow</Button>
+      </Link>
+    )
+  }
+
+  return (
+    <Button
+      onClick={following ? unfollow : follow}
+      disabled={loading}
+      className={following ? "bg-red-500 hover:bg-red-600" : "bg-teal-400 text-gray-900 hover:bg-teal-500"}
+    >
+      {following ? "Unfollow" : "Follow"}
+    </Button>
+  )
+}

--- a/lib/firebase-services.ts
+++ b/lib/firebase-services.ts
@@ -1,4 +1,4 @@
-import { collection, doc, getDocs, getDoc, addDoc, updateDoc, deleteDoc, query, where } from "firebase/firestore"
+import { collection, doc, getDocs, getDoc, addDoc, updateDoc, deleteDoc, setDoc, query, where } from "firebase/firestore"
 import { db } from "./firebase"
 import type { BlogPost, PersonalInfo, Project, Skill, Experience } from "./types"
 
@@ -11,6 +11,7 @@ const COLLECTIONS = {
   EXPERIENCE: "experience",
   ACHIEVEMENTS: "achievements",
   INTERESTS: "interests",
+  FOLLOWERS: "followers",
 }
 
 // Blog Posts Services
@@ -450,4 +451,46 @@ export const interestsService = {
       return false
     }
   },
+}
+
+// Followers Service
+export async function followBlog(userId: string): Promise<void> {
+  try {
+    await setDoc(doc(db, COLLECTIONS.FOLLOWERS, userId), {
+      userId,
+      followedAt: new Date(),
+    })
+  } catch (error) {
+    console.error("Error recording follower:", error)
+    throw error
+  }
+}
+
+export async function unfollowBlog(userId: string): Promise<void> {
+  try {
+    await deleteDoc(doc(db, COLLECTIONS.FOLLOWERS, userId))
+  } catch (error) {
+    console.error("Error removing follower:", error)
+    throw error
+  }
+}
+
+export async function getFollowerCount(): Promise<number> {
+  try {
+    const snapshot = await getDocs(collection(db, COLLECTIONS.FOLLOWERS))
+    return snapshot.size
+  } catch (error) {
+    console.error("Error fetching followers:", error)
+    return 0
+  }
+}
+
+export async function isFollowing(userId: string): Promise<boolean> {
+  try {
+    const docSnap = await getDoc(doc(db, COLLECTIONS.FOLLOWERS, userId))
+    return docSnap.exists()
+  } catch (error) {
+    console.error("Error checking follower:", error)
+    return false
+  }
 }


### PR DESCRIPTION
## Summary
- record followers in Firestore via `followBlog` and helpers
- add API endpoints to follow/unfollow and query followers
- create a FollowButton component
- expose follow buttons on blog index and details pages
- show follower count in blog stats

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841da41ce94832c9911b1fb6b627b54