### PR TITLE
Add blog view/like API and UI updates

### DIFF
--- a/app/api/blogs/[slug]/likes/route.ts
+++ b/app/api/blogs/[slug]/likes/route.ts
@@ -1,0 +1,15 @@
+import { NextRequest, NextResponse } from "next/server"
+import { blogPostsService } from "@/lib/firebase-services"
+
+export async function POST(req: NextRequest, { params }: { params: { slug: string } }) {
+  try {
+    const { userId } = await req.json()
+    if (!userId) {
+      return NextResponse.json({ success: false, error: "Missing userId" }, { status: 400 })
+    }
+    const result = await blogPostsService.toggleLike(params.slug, userId)
+    return NextResponse.json({ success: true, ...result })
+  } catch (error: any) {
+    return NextResponse.json({ success: false, error: error.message }, { status: 500 })
+  }
+}

--- a/app/api/blogs/[slug]/views/route.ts
+++ b/app/api/blogs/[slug]/views/route.ts
@@ -1,0 +1,11 @@
+import { NextRequest, NextResponse } from "next/server"
+import { blogPostsService } from "@/lib/firebase-services"
+
+export async function POST(_req: NextRequest, { params }: { params: { slug: string } }) {
+  try {
+    const views = await blogPostsService.incrementViews(params.slug)
+    return NextResponse.json({ success: true, views })
+  } catch (error: any) {
+    return NextResponse.json({ success: false, error: error.message }, { status: 500 })
+  }
+}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -14,6 +14,7 @@ export interface BlogPost {
   category: string
   trending: boolean
   featured: boolean
+  likedBy?: string[]
   createdAt?: Date
   updatedAt?: Date
 }


### PR DESCRIPTION
## Summary
- extend `BlogPost` type with optional `likedBy` field
- add `incrementViews` and `toggleLike` utilities in `firebase-services`
- expose the new utilities via `/api/blogs/[slug]/views` and `/api/blogs/[slug]/likes` routes
- update blog detail page to show view count and like button
- automatically increment views on mount and allow users to like posts

## Testing
- `pnpm lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841d956fca8832c9095ab57225a63a4