### PR TITLE
Add online status to chat

### DIFF
--- a/app/admin/chat/[roomId]/page.tsx
+++ b/app/admin/chat/[roomId]/page.tsx
@@ -26,6 +26,7 @@ function AdminChatRoomContent() {
   const [sending, setSending] = useState(false)
   const messagesEndRef = useRef<HTMLDivElement>(null)
   const [typingUser, setTypingUser] = useState<string | null>(null)
+  const [userOnline, setUserOnline] = useState(false)
   const typingTimeout = useRef<NodeJS.Timeout | null>(null)
   const currentUserName = "Ethan (Admin)"
 
@@ -48,9 +49,22 @@ function AdminChatRoomContent() {
 
     const unsubscribeTyping = chatService.onTypingStatusSnapshot(roomId, (name) => setTypingUser(name))
 
+    chatService.updateAdminOnlineStatus(roomId, true)
+    const unsubscribeUserOnline = chatService.onUserOnlineStatusSnapshot(
+      roomId,
+      (online) => setUserOnline(online),
+    )
+    const handleUnload = () => {
+      chatService.updateAdminOnlineStatus(roomId, false)
+    }
+    window.addEventListener("beforeunload", handleUnload)
+
     return () => {
       unsubscribeMessages()
       unsubscribeTyping()
+      unsubscribeUserOnline()
+      chatService.updateAdminOnlineStatus(roomId, false)
+      window.removeEventListener("beforeunload", handleUnload)
     }
   }, [roomId])
 
@@ -105,6 +119,14 @@ function AdminChatRoomContent() {
         <div>
           <h1 className="text-2xl font-bold">Chat with {userName}</h1>
           <p className="text-muted-foreground">Admin Chat Interface</p>
+          <div className="flex items-center space-x-2 mt-1">
+            <span
+              className={`h-2 w-2 rounded-full ${userOnline ? "bg-green-500" : "bg-red-500"}`}
+            />
+            <span className="text-xs text-muted-foreground">
+              {userOnline ? "Online" : "Offline"}
+            </span>
+          </div>
         </div>
         <Button variant="outline" size="sm" asChild>
           <Link href="/admin/chat">

--- a/app/chat/page.tsx
+++ b/app/chat/page.tsx
@@ -24,6 +24,7 @@ function ChatPageContent() {
   const [roomId, setRoomId] = useState<string | null>(null)
   const messagesEndRef = useRef<HTMLDivElement>(null)
   const [typingUser, setTypingUser] = useState<string | null>(null)
+  const [adminOnline, setAdminOnline] = useState(false)
   const typingTimeout = useRef<NodeJS.Timeout | null>(null)
   const currentUserName =
     user?.displayName || user?.email?.split("@")[0] || "User"
@@ -48,6 +49,13 @@ function ChatPageContent() {
         )
         setRoomId(chatRoomId)
 
+        chatService.updateUserOnlineStatus(chatRoomId, true)
+
+        const unsubscribeAdminOnline =
+          chatService.onAdminOnlineStatusSnapshot(chatRoomId, (online) =>
+            setAdminOnline(online),
+          )
+
         // Listen to messages
         const unsubscribeMessages = chatService.onMessagesSnapshot(
           chatRoomId,
@@ -68,6 +76,7 @@ function ChatPageContent() {
         return () => {
           unsubscribeMessages()
           unsubscribeTyping()
+          unsubscribeAdminOnline()
         }
       } catch (error) {
         console.error("Error initializing chat:", error)
@@ -82,6 +91,19 @@ function ChatPageContent() {
       }
     }
   }, [user])
+
+  // Update online status on unload
+  useEffect(() => {
+    if (!roomId) return
+    const handleUnload = () => {
+      chatService.updateUserOnlineStatus(roomId, false)
+    }
+    window.addEventListener("beforeunload", handleUnload)
+    return () => {
+      chatService.updateUserOnlineStatus(roomId, false)
+      window.removeEventListener("beforeunload", handleUnload)
+    }
+  }, [roomId])
 
   const handleSendMessage = async (e: React.FormEvent) => {
     e.preventDefault()
@@ -118,6 +140,9 @@ function ChatPageContent() {
 
   const handleSignOut = async () => {
     try {
+      if (roomId) {
+        await chatService.updateUserOnlineStatus(roomId, false)
+      }
       await signOut()
     } catch (error) {
       console.error("Error signing out:", error)
@@ -144,6 +169,14 @@ function ChatPageContent() {
                 <p className="text-sm text-muted-foreground">
                   Welcome, {user?.displayName || user?.email?.split("@")[0]}!
                 </p>
+                <div className="flex items-center space-x-2 mt-1">
+                  <span
+                    className={`h-2 w-2 rounded-full ${adminOnline ? "bg-green-500" : "bg-red-500"}`}
+                  />
+                  <span className="text-xs text-muted-foreground">
+                    {adminOnline ? "Online" : "Offline"}
+                  </span>
+                </div>
               </div>
               <Button variant="outline" size="sm" onClick={handleSignOut}>
                 <LogOut className="w-4 h-4 mr-2" />

--- a/lib/chat-service.ts
+++ b/lib/chat-service.ts
@@ -33,6 +33,8 @@ export interface ChatRoom {
   lastMessageTime: any
   unreadCount: number
   isActive: boolean
+  userOnline?: boolean
+  adminOnline?: boolean
   typing?: string
 }
 
@@ -105,6 +107,8 @@ export const chatService = {
         lastMessageTime: serverTimestamp(),
         unreadCount: 0,
         isActive: true,
+        userOnline: true,
+        adminOnline: false,
         createdAt: serverTimestamp(),
       })
 
@@ -193,6 +197,58 @@ export const chatService = {
     return onSnapshot(roomDoc, (snapshot) => {
       const data = snapshot.data()
       callback((data?.typing as string) || null)
+    })
+  },
+
+  // Update online status for user
+  async updateUserOnlineStatus(
+    roomId: string,
+    online: boolean,
+  ): Promise<void> {
+    try {
+      await updateDoc(doc(db, "chatRooms", roomId), {
+        userOnline: online,
+      })
+    } catch (error) {
+      console.error("Error updating user online status:", error)
+    }
+  },
+
+  // Update online status for admin
+  async updateAdminOnlineStatus(
+    roomId: string,
+    online: boolean,
+  ): Promise<void> {
+    try {
+      await updateDoc(doc(db, "chatRooms", roomId), {
+        adminOnline: online,
+      })
+    } catch (error) {
+      console.error("Error updating admin online status:", error)
+    }
+  },
+
+  // Listen to admin online status
+  onAdminOnlineStatusSnapshot(
+    roomId: string,
+    callback: (online: boolean) => void,
+  ): () => void {
+    const roomDoc = doc(db, "chatRooms", roomId)
+    return onSnapshot(roomDoc, (snapshot) => {
+      const data = snapshot.data()
+      callback(Boolean(data?.adminOnline))
+    })
+  },
+
+  // Listen to user online status
+  onUserOnlineStatusSnapshot(
+    roomId: string,
+    callback: (online: boolean) => void,
+  ): () => void {
+    const roomDoc = doc(db, "chatRooms", roomId)
+    return onSnapshot(roomDoc, (snapshot) => {
+      const data = snapshot.data()
+      callback(Boolean(data?.userOnline))
     })
   },
 }


### PR DESCRIPTION
## Summary
- show online/offline indicator in chat pages
- track online presence with new flags in chat room docs

## Testing
- `npm run lint` *(fails: next not found)*
- `npx tsc --noEmit` *(fails: cannot find module 'react' etc.)*

------
https://chatgpt.com/codex/tasks/task_e_684228f47700832c92e78793240d60bb