### PR TITLE
Add online focus detection

### DIFF
--- a/lib/chat-service.ts
+++ b/lib/chat-service.ts
@@ -33,6 +33,8 @@ export interface ChatRoom {
   lastMessageTime: any
   unreadCount: number
   isActive: boolean
+  userOnline?: boolean
+  adminOnline?: boolean
   typing?: string
 }
 
@@ -105,6 +107,8 @@ export const chatService = {
         lastMessageTime: serverTimestamp(),
         unreadCount: 0,
         isActive: true,
+        userOnline: true,
+        adminOnline: false,
         createdAt: serverTimestamp(),
       })
 
@@ -193,6 +197,58 @@ export const chatService = {
     return onSnapshot(roomDoc, (snapshot) => {
       const data = snapshot.data()
       callback((data?.typing as string) || null)
+    })
+  },
+
+  // Update online status for user
+  async updateUserOnlineStatus(
+    roomId: string,
+    online: boolean,
+  ): Promise<void> {
+    try {
+      await updateDoc(doc(db, "chatRooms", roomId), {
+        userOnline: online,
+      })
+    } catch (error) {
+      console.error("Error updating user online status:", error)
+    }
+  },
+
+  // Update online status for admin
+  async updateAdminOnlineStatus(
+    roomId: string,
+    online: boolean,
+  ): Promise<void> {
+    try {
+      await updateDoc(doc(db, "chatRooms", roomId), {
+        adminOnline: online,
+      })
+    } catch (error) {
+      console.error("Error updating admin online status:", error)
+    }
+  },
+
+  // Listen to admin online status
+  onAdminOnlineStatusSnapshot(
+    roomId: string,
+    callback: (online: boolean) => void,
+  ): () => void {
+    const roomDoc = doc(db, "chatRooms", roomId)
+    return onSnapshot(roomDoc, (snapshot) => {
+      const data = snapshot.data()
+      callback(Boolean(data?.adminOnline))
+    })
+  },
+
+  // Listen to user online status
+  onUserOnlineStatusSnapshot(
+    roomId: string,
+    callback: (online: boolean) => void,
+  ): () => void {
+    const roomDoc = doc(db, "chatRooms", roomId)
+    return onSnapshot(roomDoc, (snapshot) => {
+      const data = snapshot.data()
+      callback(Boolean(data?.userOnline))
     })
   },
 }


### PR DESCRIPTION
## Summary
- update online status based on page focus on user chat page
- update online status based on page focus on admin chat room

## Testing
- `npm run lint` *(fails: next not found)*
- `npx tsc --noEmit` *(fails: cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_684228f47700832c92e78793240d60bb