### PR TITLE
Improve chat online status

### DIFF
--- a/app/admin/chat/[roomId]/page.tsx
+++ b/app/admin/chat/[roomId]/page.tsx
@@ -54,9 +54,22 @@ function AdminChatRoomContent() {
       roomId,
       (online) => setUserOnline(online),
     )
-    const handleUnload = () => {
-      chatService.updateAdminOnlineStatus(roomId, false)
+
+    const updateStatus = (online: boolean) =>
+      chatService.updateAdminOnlineStatus(roomId, online)
+
+    const handleVisibility = () => {
+      updateStatus(document.visibilityState === "visible")
     }
+
+    const handleFocus = () => updateStatus(true)
+    const handleBlur = () => updateStatus(false)
+    const handleUnload = () => updateStatus(false)
+
+    updateStatus(document.visibilityState === "visible")
+    window.addEventListener("focus", handleFocus)
+    window.addEventListener("blur", handleBlur)
+    document.addEventListener("visibilitychange", handleVisibility)
     window.addEventListener("beforeunload", handleUnload)
 
     return () => {
@@ -64,6 +77,9 @@ function AdminChatRoomContent() {
       unsubscribeTyping()
       unsubscribeUserOnline()
       chatService.updateAdminOnlineStatus(roomId, false)
+      window.removeEventListener("focus", handleFocus)
+      window.removeEventListener("blur", handleBlur)
+      document.removeEventListener("visibilitychange", handleVisibility)
       window.removeEventListener("beforeunload", handleUnload)
     }
   }, [roomId])

--- a/app/chat/page.tsx
+++ b/app/chat/page.tsx
@@ -92,15 +92,32 @@ function ChatPageContent() {
     }
   }, [user])
 
-  // Update online status on unload
+  // Update online status based on tab focus
   useEffect(() => {
     if (!roomId) return
-    const handleUnload = () => {
-      chatService.updateUserOnlineStatus(roomId, false)
+
+    const updateStatus = (online: boolean) =>
+      chatService.updateUserOnlineStatus(roomId, online)
+
+    const handleVisibility = () => {
+      updateStatus(document.visibilityState === "visible")
     }
+
+    const handleFocus = () => updateStatus(true)
+    const handleBlur = () => updateStatus(false)
+    const handleUnload = () => updateStatus(false)
+
+    updateStatus(document.visibilityState === "visible")
+    window.addEventListener("focus", handleFocus)
+    window.addEventListener("blur", handleBlur)
+    document.addEventListener("visibilitychange", handleVisibility)
     window.addEventListener("beforeunload", handleUnload)
+
     return () => {
-      chatService.updateUserOnlineStatus(roomId, false)
+      updateStatus(false)
+      window.removeEventListener("focus", handleFocus)
+      window.removeEventListener("blur", handleBlur)
+      document.removeEventListener("visibilitychange", handleVisibility)
       window.removeEventListener("beforeunload", handleUnload)
     }
   }, [roomId])


### PR DESCRIPTION
## Summary
- update user chat to set online/offline based on tab focus
- update admin chat page with same focus based status

## Testing
- `pnpm lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68422c494780832cb29fd2d0ec4216be