### PR TITLE
Add portfolio site icon

### DIFF
--- a/app/icon.svg
+++ b/app/icon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <rect width="64" height="64" rx="10" fill="#14b8a6"/>
+  <text x="32" y="42" font-size="36" font-family="Arial, Helvetica, sans-serif" text-anchor="middle" fill="white">E</text>
+</svg>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -11,7 +11,10 @@ export const metadata: Metadata = {
   title: "Ethan Yu - Full-Stack Developer",
   description:
     "Portfolio website of Ethan Yu, a passionate full-stack developer specializing in React, Node.js, and modern web technologies.",
-    generator: 'v0.dev'
+  generator: "v0.dev",
+  icons: {
+    icon: "/icon.svg",
+  },
 }
 
 export default function RootLayout({


### PR DESCRIPTION
## Summary
- add basic portfolio site icon
- reference the icon in metadata

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68422dee7290832c890734ce9755f0cf