### PR TITLE
Fix experience model and editing

### DIFF
--- a/lib/firebase-services.ts
+++ b/lib/firebase-services.ts
@@ -294,12 +294,8 @@ export const experienceService = {
         ...doc.data(),
       })) as Experience[]
 
-      // Sort by start date on client side (most recent first)
-      return experiences.sort((a, b) => {
-        const dateA = new Date(a.startDate).getTime()
-        const dateB = new Date(b.startDate).getTime()
-        return dateB - dateA
-      })
+      // Sort by order if present
+      return experiences.sort((a, b) => (a.order ?? 0) - (b.order ?? 0))
     } catch (error) {
       console.error("Error fetching experience:", error)
       return []

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -74,13 +74,11 @@ export interface Experience {
   title: string
   company: string
   location: string
-  startDate: string
-  endDate?: string
+  period: string
   current: boolean
   description: string
   achievements: string[]
   order?: number
-  period?: string
 }
 
 export interface Achievement {

--- a/scripts/init-firebase-data.ts
+++ b/scripts/init-firebase-data.ts
@@ -148,7 +148,7 @@ export async function initializeFirebaseData() {
         title: "Senior Full-Stack Developer",
         company: "Tech Solutions Inc.",
         location: "San Francisco, CA",
-        startDate: "2022-01-01",
+        period: "2022 - Present",
         current: true,
         description:
           "Leading development of scalable web applications using React, Node.js, and cloud technologies. Mentoring junior developers and implementing best practices.",
@@ -163,8 +163,7 @@ export async function initializeFirebaseData() {
         title: "Full-Stack Developer",
         company: "Digital Agency",
         location: "San Francisco, CA",
-        startDate: "2020-01-01",
-        endDate: "2021-12-31",
+        period: "2020 - 2021",
         current: false,
         description:
           "Developed and maintained multiple client projects, focusing on responsive design and performance optimization.",


### PR DESCRIPTION
## Summary
- update `Experience` type to use period instead of start and end dates
- adjust firebase service sorting for updated experience model
- modify firebase init data to match new structure
- overhaul admin settings experience section
  - new input fields for period and achievements
  - editable dialog for existing experiences

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842a91cc19c832caff116b2a508c7fa