### PR TITLE
Add basic SEO metadata and sitemap

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -8,10 +8,61 @@ import { AuthProvider } from "@/contexts/auth-context"
 const inter = Inter({ subsets: ["latin"] })
 
 export const metadata: Metadata = {
-  title: "Ethan Yu - Full-Stack Developer",
+  metadataBase: new URL("https://ethanyu.dev"),
+  title: {
+    default: "Ethan Yu - Full-Stack Developer",
+    template: "%s | Ethan Yu",
+  },
   description:
     "Portfolio website of Ethan Yu, a passionate full-stack developer specializing in React, Node.js, and modern web technologies.",
+  keywords: [
+    "Ethan Yu",
+    "Full-Stack Developer",
+    "React",
+    "Node.js",
+    "Portfolio",
+  ],
   generator: "v0.dev",
+  alternates: {
+    canonical: "/",
+  },
+  openGraph: {
+    title: "Ethan Yu - Full-Stack Developer",
+    description:
+      "Portfolio website of Ethan Yu, a passionate full-stack developer specializing in React, Node.js, and modern web technologies.",
+    url: "https://ethanyu.dev",
+    siteName: "EthanYu Portfolio",
+    images: [
+      {
+        url: "/images/avatar.png",
+        width: 1200,
+        height: 630,
+        alt: "Ethan Yu - Full-Stack Developer",
+      },
+    ],
+    locale: "en_US",
+    type: "website",
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "Ethan Yu - Full-Stack Developer",
+    description:
+      "Portfolio website of Ethan Yu, a passionate full-stack developer specializing in React, Node.js, and modern web technologies.",
+    creator: "@ethanyu",
+    images: ["/images/avatar.png"],
+  },
+  robots: {
+    index: true,
+    follow: true,
+    googleBot: {
+      index: true,
+      follow: true,
+    },
+  },
+  viewport: {
+    width: "device-width",
+    initialScale: 1,
+  },
   icons: {
     icon: "/icon.svg",
   },

--- a/app/robots.txt/route.ts
+++ b/app/robots.txt/route.ts
@@ -1,0 +1,10 @@
+const BASE_URL = process.env.NEXT_PUBLIC_SITE_URL || "https://ethanyu.dev"
+
+export async function GET() {
+  const body = `User-agent: *\nAllow: /\nSitemap: ${BASE_URL}/sitemap.xml`
+  return new Response(body, {
+    headers: {
+      "Content-Type": "text/plain",
+    },
+  })
+}

--- a/app/sitemap.xml/route.ts
+++ b/app/sitemap.xml/route.ts
@@ -1,0 +1,43 @@
+import { blogPostsService, projectsService } from "@/lib/firebase-services"
+import { fallbackBlogPosts, fallbackProjects } from "@/lib/fallback-data"
+
+const BASE_URL = process.env.NEXT_PUBLIC_SITE_URL || "https://ethanyu.dev"
+
+function generateSiteMap(urls: string[]) {
+  return `<?xml version="1.0" encoding="UTF-8"?>\n<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n${urls
+    .map((url) => `  <url><loc>${url}</loc></url>`) 
+    .join("\n")}\n</urlset>`
+}
+
+export async function GET() {
+  let posts = []
+  let projects = []
+  try {
+    posts = await blogPostsService.getAll()
+  } catch {
+    posts = []
+  }
+  if (posts.length === 0) posts = fallbackBlogPosts
+  try {
+    projects = await projectsService.getAll()
+  } catch {
+    projects = []
+  }
+  if (projects.length === 0) projects = fallbackProjects
+
+  const staticPages = ["", "/about", "/blogs", "/projects", "/chat"]
+
+  const urls = [
+    ...staticPages.map((p) => `${BASE_URL}${p}`),
+    ...posts.map((post) => `${BASE_URL}/blogs/${post.slug}`),
+    ...projects.map((proj) => `${BASE_URL}/projects/${proj.id}`),
+  ]
+
+  const body = generateSiteMap(urls)
+
+  return new Response(body, {
+    headers: {
+      "Content-Type": "application/xml",
+    },
+  })
+}


### PR DESCRIPTION
## Summary
- expand page metadata with Open Graph, Twitter, keywords, robots and viewport
- add dynamic sitemap.xml route
- add robots.txt route

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842e712abc8832c8e298706da682710